### PR TITLE
Updating Newtonsoft to Latest

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "2.0.0"
+    "version": "3.1.421",
+    "rollForward": "latestMinor"
   }
 }

--- a/src/Serilog.Sinks.Slack.Core.TestConsoleApp/Serilog.Sinks.Slack.Core.TestConsoleApp.csproj
+++ b/src/Serilog.Sinks.Slack.Core.TestConsoleApp/Serilog.Sinks.Slack.Core.TestConsoleApp.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.5.0" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.Slack.Core/Serilog.Sinks.Slack.Core.csproj
+++ b/src/Serilog.Sinks.Slack.Core/Serilog.Sinks.Slack.Core.csproj
@@ -23,7 +23,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.5.0" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.Slack.TestConsoleApp/Serilog.Sinks.Slack.TestConsoleApp.csproj
+++ b/src/Serilog.Sinks.Slack.TestConsoleApp/Serilog.Sinks.Slack.TestConsoleApp.csproj
@@ -52,6 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="FSharp.Core">
@@ -59,9 +62,6 @@
     </Reference>
     <Reference Include="FSharp.Data">
       <HintPath>..\..\packages\FSharp.Data.2.4.2\lib\net45\FSharp.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>

--- a/src/Serilog.Sinks.Slack.TestConsoleApp/packages.config
+++ b/src/Serilog.Sinks.Slack.TestConsoleApp/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FSharp.Core" version="4.2.3" targetFramework="net451" />
   <package id="FSharp.Data" version="2.4.2" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net451" />
   <package id="Serilog" version="2.5.0" targetFramework="net451" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net451" />
 </packages>

--- a/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
+++ b/src/Serilog.Sinks.Slack/Serilog.Sinks.Slack.csproj
@@ -50,6 +50,9 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
@@ -59,9 +62,6 @@
     </Reference>
     <Reference Include="FSharp.Data">
       <HintPath>..\..\packages\FSharp.Data.2.4.2\lib\net45\FSharp.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\..\packages\Serilog.2.5.0\lib\net45\Serilog.dll</HintPath>

--- a/src/Serilog.Sinks.Slack/packages.config
+++ b/src/Serilog.Sinks.Slack/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FSharp.Core" version="4.2.3" targetFramework="net451" />
   <package id="FSharp.Data" version="2.4.2" targetFramework="net451" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net451" />
   <package id="OctoPack" version="3.6.1" targetFramework="net451" developmentDependency="true" />
   <package id="Serilog" version="2.5.0" targetFramework="net451" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net451" />


### PR DESCRIPTION
Hi,

I didn't see any PR guidelines in this repository, so please let me know if you need any additional information or work. I would like to restrict this PR to just updating Newtonsoft if possible.

**Background**
We are doing some security related updates to our dependencies and would like to get this project updated too. Since there's not much that's automated I did my best to fully get this working in both versions before upgrading but was unable to get .Net Framework project to successfully post to slack.

**Steps**
1. Pull down the project and get it building. (Never worked with FSharp, had to run this on a VM because Mono and dotnet core were not playing nice on my mac.)
2. Get the project to build. The oldest version of dotnet core sdk I had installed was 3.x. After installing 2.0.x I had to update the FSharp targets in order to get the build to pass. Let me know if you need that change set to get the build working locally for you too.
3. Verify the project works. Two things:  
    1. Unfortunately I could not get the .Net Framework 4 version to work. This included both the webhook and app configurations using your samples. I verified my tokens were right by using raw requests with postman first just to be extra sure.
    2. I also had to disable older versions of TLS, I kept getting an error regarding SSL.
5. Update the package ✅ 
6. Verify it still works the same as before ✅ 

If you're willing to drop support for .Net 4 I would be up for putting together another PR to get this on the latest version of dotnet core and getting the app configuration working because it looks like slack is [dropping support for webhooks](https://api.slack.com/legacy/custom-integrations).

Thanks,
Matt